### PR TITLE
fix: separate session secret and use edge iron-session

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 DATABASE_URL="file:./dev.db"
 SITE_NAME="Daily Cleaning Log"
 ADMIN_PASSWORD="change_me"
+SESSION_PASSWORD="change_this_session_secret_to_at_least_32_chars"
 RESEND_API_KEY=""
 SMTP_HOST=""
 SMTP_PORT="587"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Visit `http://localhost:3000` for the feed and `http://localhost:3000/admin` for
 4. Add environment variables from `.env.example` in Render dashboard.
 
 ## Environment Variables
-See `.env.example` for required variables like `ADMIN_PASSWORD`, SMTP or Resend settings, and `DATABASE_URL`.
+See `.env.example` for required variables like `ADMIN_PASSWORD`, a long `SESSION_PASSWORD` for cookie encryption, SMTP or Resend settings, and `DATABASE_URL`.
 
 ## Python
 

--- a/app/api/delete/[id]/route.ts
+++ b/app/api/delete/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { getIronSession } from 'iron-session';
+import { getIronSession } from 'iron-session/edge';
 import { sessionOptions, SessionData } from '../../../../lib/auth';
 import { prisma } from '../../../../lib/db';
 

--- a/app/api/login/route.ts
+++ b/app/api/login/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { getIronSession } from 'iron-session';
+import { getIronSession } from 'iron-session/edge';
 import { sessionOptions, SessionData } from '../../../lib/auth';
 
 export async function POST(req: Request) {

--- a/app/api/post/route.ts
+++ b/app/api/post/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { getIronSession } from 'iron-session';
+import { getIronSession } from 'iron-session/edge';
 import { sessionOptions, SessionData } from '../../../lib/auth';
 import { prisma } from '../../../lib/db';
 import { saveFile } from '../../../lib/storage';

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,7 +1,9 @@
 import { IronSessionOptions } from 'iron-session';
 
 export const sessionOptions: IronSessionOptions = {
-  password: process.env.ADMIN_PASSWORD || 'change_me',
+  password:
+    process.env.SESSION_PASSWORD ||
+    'session_password_at_least_32_chars_long',
   cookieName: 'cleaning_session',
   cookieOptions: {
     secure: process.env.NODE_ENV === 'production',


### PR DESCRIPTION
## Summary
- use dedicated `SESSION_PASSWORD` for iron-session and document it
- switch API routes to `iron-session/edge` to save sessions correctly

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@prisma%2fclient)*
- `npm test` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b91b1fc9b0832b92049f6adb9d854f